### PR TITLE
adding the seed option for the simulate mode

### DIFF
--- a/src/seqrequester/seqrequester.C
+++ b/src/seqrequester/seqrequester.C
@@ -274,6 +274,12 @@ main(int argc, char **argv) {
       simPar.rcProb = strtodouble(argv[++arg]);
     }
 
+    else if ((mode == modeSimulate) && (strcmp(argv[arg], "-seed") == 0)) {
+      simPar.randomSeedValid = true;
+      simPar.randomSeed      = strtouint32(argv[++arg]);
+    }
+
+
     //else if ((mode == modeSimulate) && (strcmp(argv[arg], "-name") == 0)) {
     //  strncpy(simPar.sequenceName, argv[++arg], FILENAME_MAX);
     //}

--- a/src/seqrequester/simulate.C
+++ b/src/seqrequester/simulate.C
@@ -469,6 +469,11 @@ doSimulate(vector<char *>     &inputs,
   uint64            seqsLen = 0;
 
   doSimulate_loadSequences(simPar, seqs, seqsLen);
+  // Reset nBaseMax when the coverage is given while the genomeSize is not
+  if ( (simPar.desiredCoverage > 0) && (simPar.genomeSize == 0) ) {
+      simPar.genomeSize = seqsLen;
+      nBasesMax = simPar.desiredCoverage * simPar.genomeSize;
+  }
 
   //  Make reads!
 

--- a/src/seqrequester/simulate.C
+++ b/src/seqrequester/simulate.C
@@ -446,6 +446,9 @@ doSimulate(vector<char *>     &inputs,
   if (simPar.desiredNumBases > 0)
     nBasesMax = simPar.desiredNumBases;
 
+  if (simPar.randomSeedValid)
+    simPar.mt.mtSetSeed(simPar.randomSeed);
+
   //  Fail?
 
   if ((nBasesMax == uint64max) &&

--- a/src/seqrequester/simulate.H
+++ b/src/seqrequester/simulate.H
@@ -55,6 +55,9 @@ public:
 
   double  rcProb             = 0.5;
 
+  bool    randomSeedValid    = false;
+  uint32  randomSeed         = 0;
+
   mtRandom             mt;
   sampledDistribution  dist;
 


### PR DESCRIPTION
For the `simulate` mode, it would make sense to have the seed option so that experiments can be done repeatedly across different machines without having to copy the data.

A log to varify that the added seed option works: 
```
[xan34@login-hive1 src]$ ../build/bin/seqrequester simulate -truncate -genome ~/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa -coverage 20 -distribution ../share/pacbio-hifi -genomesize 138142 > res1
load '../share/pacbio-hifi'
Loading sequences from '/storage/home/hhive1/xan34/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa'
Loaded 1 sequences.
[xan34@login-hive1 src]$ ../build/bin/seqrequester simulate -truncate -genome ~/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa -coverage 20 -distribution ../share/pacbio-hifi -genomesize 138142 > res2
load '../share/pacbio-hifi'
Loading sequences from '/storage/home/hhive1/xan34/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa'
Loaded 1 sequences.
[xan34@login-hive1 src]$ ../build/bin/seqrequester simulate -truncate -genome ~/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa -coverage 20 -distribution ../share/pacbio-hifi -genomesize 138142 -seed 1 > res3
load '../share/pacbio-hifi'
Loading sequences from '/storage/home/hhive1/xan34/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa'
Loaded 1 sequences.
[xan34@login-hive1 src]$ ../build/bin/seqrequester simulate -truncate -genome ~/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa -coverage 20 -distribution ../share/pacbio-hifi -genomesize 138142 -seed 1 > res4
load '../share/pacbio-hifi'
Loading sequences from '/storage/home/hhive1/xan34/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa'
Loaded 1 sequences.
[xan34@login-hive1 src]$ ../build/bin/seqrequester simulate -truncate -genome ~/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa -coverage 20 -distribution ../share/pacbio-hifi -genomesize 138142 -seed 2 > res5
load '../share/pacbio-hifi'
Loading sequences from '/storage/home/hhive1/xan34/data/spx/StringBOA_LFS/base_genomes/fruitfly.fa'
Loaded 1 sequences.
[xan34@login-hive1 src]$ for f in ./res*; do echo "$f"; md5sum $f; done
./res1
887cad69ce89fed9a8547cf60b4687bd  ./res1
./res2
1a1bf74250c06b04fe860951e7831e9c  ./res2
./res3
99ee3df6e0dcc18f36c28906972c3d56  ./res3
./res4
99ee3df6e0dcc18f36c28906972c3d56  ./res4
./res5
31fb1bc3c241a5e11463483d8b442886  ./res5
[xan34@login-hive1 src]$
```